### PR TITLE
Sanitize one line function definitions.

### DIFF
--- a/api/mux_server.jl
+++ b/api/mux_server.jl
@@ -10,9 +10,14 @@ expr_has_head(e::Expr, h::Symbol) = expr_has_head(e, Symbol[h])
 function expr_has_head(e::Expr, vh::Vector{Symbol})
     in(e.head, vh) || any(a -> expr_has_head(a, vh), e.args)
 end
-has_function_def(s::String) = has_function_def(parse(s; raise=false))
-has_function_def(e::Expr) = expr_has_head(e, Symbol[:(->), :function])
 
+has_function_def(s::String) = has_function_def(parse(s; raise=false))
+function has_function_def(e::Expr)
+    expr_has_head(e, Symbol[:(->), :function]) ||
+    # one line funtion definition:
+    (expr_has_head(e, :(=)) && expr_has_head(e.args[], :call))
+end
+    
 # Headers -- set Access-Control-Allow-Origin for either dev or prod
 function withHeaders(res, req)
     println("Origin: ", get(req[:headers], "Origin", ""))


### PR DESCRIPTION
![](    https://s30.postimg.org/9cet1lhmp/Screenshot_2017_01_16_00_58_22.png   )

```
2017-01-16T06:43:42.491625+00:00 app[web.1]: Diff equ: begin  # none, line 2:
2017-01-16T06:43:42.492112+00:00 app[web.1]:     dx = a * x - b * x * y # none, line 3:
2017-01-16T06:43:42.492524+00:00 app[web.1]:     dy = -c * y + d * x * y * begin 
2017-01-16T06:43:42.492805+00:00 app[web.1]:                     foo() = begin  # none, line 3:
2017-01-16T06:43:42.492961+00:00 app[web.1]:                             println(:foo)
2017-01-16T06:43:42.493042+00:00 app[web.1]:                         end
2017-01-16T06:43:42.493143+00:00 app[web.1]:                     foo()
2017-01-16T06:43:42.493193+00:00 app[web.1]:                 end
2017-01-16T06:43:42.493238+00:00 app[web.1]: end
2017-01-16T06:43:42.494120+00:00 app[web.1]: Params: Expr[:(a = 1.5),:(b = 1),:(c = 3),:(d = 1)]
2017-01-16T06:43:42.494264+00:00 app[web.1]: tspan: (0.0,10.0)
2017-01-16T06:43:42.494434+00:00 app[web.1]: u0: [1.0,1.0]
2017-01-16T06:43:42.494972+00:00 app[web.1]: vars: Symbol[:x,:y] type: Array{Symbol,1}
2017-01-16T06:43:42.496822+00:00 app[web.1]: WARNING: Method definition foo() in module ParameterizedFunctions at none:3 overwritten at none:3.
2017-01-16T06:43:42.501120+00:00 app[web.1]: foo
```

***

```julia
julia> has_function_def(:(foo()=:foo))
true
```